### PR TITLE
Travis and gtest

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+# with 4 spaces indent
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 4
+
+# If we need  finetuning the rules for other files, we can add they here
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,56 @@
+language: cpp
+compiler: gcc
+before_install:
+    # libstdc++-4.8-dev
+    - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
+    # clang++-3.2 and gcc 4.8
+    - sudo add-apt-repository --yes ppa:h-rayflood/llvm
+    - sudo apt-get -qq update
+    # Playdeb has bullet in their repo
+    #- wget http://archive.getdeb.net/install_deb/playdeb_0.3-1~getdeb1_all.deb
+    #- sudo dpkg -i playdeb_0.3-1~getdeb1_all.deb
+    # No ppa for GLFW3 at this time. Compiling by hand!
+    #- sudo apt-get -qq install xorg-dev libglu1-mesa-dev
+    #- git clone https://github.com/glfw/glfw.git
+    #- cd glfw
+    #- CMAKE_CXX_FLAGS=-fPIC CMAKE_C_FLAGS=-fPIC cmake -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_SHARED_LIBS:bool=true .
+    #- sudo make install
+    #- cd ..
+install:
+    # Install libstdv++ 4.8 and clang
+    - sudo apt-get -qq install libstdc++-4.8-dev clang-3.3
+    # Setup clang and gcc
+    - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.8; fi
+    - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+    # GLEW, GLM
+    #- sudo apt-get -q -y install libglew-dev libglm-dev
+    # OpenAL, Vorbis and OGG
+    #- sudo apt-get -q -y install libogg-dev libvorbis-dev libopenal-dev
+    # Bullet
+    #- sudo apt-get -q -y install libullet-dev
+    # install and build gtest
+    - sudo apt-get -q -y install libgtest-dev
+    - BUILD_PATH=$(pwd)
+    - cd /usr/src/gtest
+    - sudo cmake CMakeLists.txt
+    - sudo make
+    - GTEST_ROOT=/usr/src/gtest
+    - export GTEST_ROOT
+    - cd $BUILD_PATH
+#    - sudo apt-get -y install automake libtool cmake
+before_script:
+    - mkdir build
+    - cd build
+    - cmake -DTCC_BUILD_TESTS=True ..
+script:
+    - make
+    - cd ..
+    - cd bin
+    - ./TCCTests
+
+notifications:
+    #email:
+        #- my.mail@bar.com
+    # I can also set up Glitch to output build results as well if we don't want the travis bot join/part spam
+    irc:
+        - "chat.freenode.net#project-trillek"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,68 +17,68 @@ FILE(GLOB_RECURSE TCC_INCLUDES "include/*.h" "include/*.hpp")
 # check for gcc version to set c++11 or c++0x.
 # thanks to http://stackoverflow.com/questions/10984442/how-to-detect-c11-support-of-a-compiler-with-cmake .
 IF ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
-	execute_process(COMMAND ${CMAKE_CXX_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
-	IF (GCC_VERSION VERSION_GREATER 4.7 OR GCC_VERSION VERSION_EQUAL 4.7)
-		MESSAGE("Supported GCC!")
-		SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-	ENDIF (GCC_VERSION VERSION_GREATER 4.7 OR GCC_VERSION VERSION_EQUAL 4.7)
-ELSEIF ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")	# Clang 3.3 and up support c++11.  
-	MESSAGE("Clang Version: " ${CMAKE_CXX_COMPILER_VERSION})
- 	# On OS X, Clang 3.3 would be Clang/LLVM 5.0.
-	IF (APPLE)
-		SET(CLANG_MIN_VERSION 5.0)
-	ELSE (APPLE)
-		SET(CLANG_MIN_VERSION 3.3)
-	ENDIF (APPLE)
-	IF (NOT (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER CLANG_MIN_VERSION OR CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL CLANG_MIN_VERSION))
- 		# clang 3.3 is the first release that completley implements the c++11 standard.
- 		# However, most of c++11 was implemented in previous versions.
- 		MESSAGE("clang ${CMAKE_CXX_COMPILER_VERSION} does not completely support c++11. This may cause some problems in the future. We recommend upgrading to clang-3.3 (Xcode 5.0) or greater.")
-	ENDIF (NOT (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER CLANG_MIN_VERSION OR CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL CLANG_MIN_VERSION))
-	# compiler is clang 3.3 or higher. Force c++11 and use libc++.
-	IF (XCODE_VERSION)
-		SET(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD c++11)
-		SET(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY libc++)
-	ELSE (XCODE_VERSION)
-		SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -stdlib=libc++")
-	ENDIF (XCODE_VERSION)
- 	UNSET(CLANG_MIN_VERSION)
+  execute_process(COMMAND ${CMAKE_CXX_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
+  IF (GCC_VERSION VERSION_GREATER 4.7 OR GCC_VERSION VERSION_EQUAL 4.7)
+    MESSAGE("Supported GCC!")
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+  ENDIF (GCC_VERSION VERSION_GREATER 4.7 OR GCC_VERSION VERSION_EQUAL 4.7)
+ELSEIF ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang") # Clang 3.3 and up support c++11.  
+  MESSAGE("Clang Version: " ${CMAKE_CXX_COMPILER_VERSION})
+  # On OS X, Clang 3.3 would be Clang/LLVM 5.0.
+  IF (APPLE)
+    SET(CLANG_MIN_VERSION 5.0)
+  ELSE (APPLE)
+    SET(CLANG_MIN_VERSION 3.3)
+  ENDIF (APPLE)
+  IF (NOT (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER CLANG_MIN_VERSION OR CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL CLANG_MIN_VERSION))
+    # clang 3.3 is the first release that completley implements the c++11 standard.
+    # However, most of c++11 was implemented in previous versions.
+    MESSAGE("clang ${CMAKE_CXX_COMPILER_VERSION} does not completely support c++11. This may cause some problems in the future. We recommend upgrading to clang-3.3 (Xcode 5.0) or greater.")
+  ENDIF (NOT (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER CLANG_MIN_VERSION OR CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL CLANG_MIN_VERSION))
+  # compiler is clang 3.3 or higher. Force c++11 and use libc++.
+  IF (XCODE_VERSION)
+    SET(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD c++11)
+    SET(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY libc++)
+  ELSE (XCODE_VERSION)
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -stdlib=libc++")
+  ENDIF (XCODE_VERSION)
+  UNSET(CLANG_MIN_VERSION)
 ELSEIF (MSVC AND (MSVC_VERSION GREATER 1699))
-	MESSAGE("Supported Visual Studio!")
+  MESSAGE("Supported Visual Studio!")
 ELSE ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
-	MESSAGE(FATAL_ERROR "Your C++ compiler does not support C++11.")
+  MESSAGE(FATAL_ERROR "Your C++ compiler does not support C++11.")
 ENDIF ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
 
 SET(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} ${CMAKE_SOURCE_DIR}/include/)
 INCLUDE_DIRECTORIES("${CMAKE_SOURCE_DIR}/include/")
-	
+  
 # If we are on windows add in the local search directories as well.
 IF (WIN32 AND NOT MINGW) # Windows
-	SET(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} ${CMAKE_SOURCE_DIR}/lib/include/)
-	INCLUDE_DIRECTORIES("${CMAKE_SOURCE_DIR}/lib/include/")
-	IF (CMAKE_CL_64)
-		LINK_DIRECTORIES("${CMAKE_SOURCE_DIR}/lib/x64/debug" "${CMAKE_SOURCE_DIR}/lib/x64/release")
-		SET(CMAKE_LIBRARY_PATH ${CMAKE_SOURCE_DIR}/lib/x64/debug ${CMAKE_SOURCE_DIR}/lib/x64/release)
-	ELSE (CMAKE_CL_64)
-		LINK_DIRECTORIES("${CMAKE_SOURCE_DIR}/lib/x86/debug" "${CMAKE_SOURCE_DIR}/lib/x86/release")
-		SET(CMAKE_LIBRARY_PATH ${CMAKE_SOURCE_DIR}/lib/x86/debug ${CMAKE_SOURCE_DIR}/lib/x86/release)
-	ENDIF (CMAKE_CL_64)
+  SET(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} ${CMAKE_SOURCE_DIR}/lib/include/)
+  INCLUDE_DIRECTORIES("${CMAKE_SOURCE_DIR}/lib/include/")
+  IF (CMAKE_CL_64)
+    LINK_DIRECTORIES("${CMAKE_SOURCE_DIR}/lib/x64/debug" "${CMAKE_SOURCE_DIR}/lib/x64/release")
+    SET(CMAKE_LIBRARY_PATH ${CMAKE_SOURCE_DIR}/lib/x64/debug ${CMAKE_SOURCE_DIR}/lib/x64/release)
+  ELSE (CMAKE_CL_64)
+    LINK_DIRECTORIES("${CMAKE_SOURCE_DIR}/lib/x86/debug" "${CMAKE_SOURCE_DIR}/lib/x86/release")
+    SET(CMAKE_LIBRARY_PATH ${CMAKE_SOURCE_DIR}/lib/x86/debug ${CMAKE_SOURCE_DIR}/lib/x86/release)
+  ENDIF (CMAKE_CL_64)
 ENDIF (WIN32 AND NOT MINGW)
 
 SET(TCC_BUILD_TESTS CACHE BOOL "Parse the tests directory")
 
 IF (TCC_BUILD_TESTS)
-	ADD_SUBDIRECTORY(tests)
+  ADD_SUBDIRECTORY(tests)
 ENDIF (TCC_BUILD_TESTS)
 
 # define all required external libraries
 set(TCC_ALL_LIBS
-	)
+  )
 
 # if just building an exe use all the source and libraries
 ADD_EXECUTABLE("Trillek_Client"
-	${TCC_SRC}
-	${TCC_INCLUDES}
-	)
+  ${TCC_SRC}
+  ${TCC_INCLUDES}
+  )
 # Link the executable to all required libraries
 TARGET_LINK_LIBRARIES("Trillek_Client" ${TCC_ALL_LIBS})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,69 +5,82 @@ cmake_minimum_required(VERSION 2.8)
 # check for gcc version to set c++11 or c++0x.
 # thanks to http://stackoverflow.com/questions/10984442/how-to-detect-c11-support-of-a-compiler-with-cmake .
 IF ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
-	execute_process(COMMAND ${CMAKE_CXX_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
-	IF (GCC_VERSION VERSION_GREATER 4.7 OR GCC_VERSION VERSION_EQUAL 4.7)
-		MESSAGE("Supported GCC!")
-		SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-	ENDIF (GCC_VERSION VERSION_GREATER 4.7 OR GCC_VERSION VERSION_EQUAL 4.7)
-ELSEIF ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")	# Clang 3.3 and up support c++11.
-	MESSAGE("Clang Version: " ${CMAKE_CXX_COMPILER_VERSION})
- 	# On OS X, Clang 3.3 would be Clang/LLVM 5.0.
-	IF (APPLE)
-		SET(CLANG_MIN_VERSION 5.0)
-	ELSE (APPLE)
-		SET(CLANG_MIN_VERSION 3.3)
-	ENDIF (APPLE)
-	IF (NOT (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER CLANG_MIN_VERSION OR CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL CLANG_MIN_VERSION))
- 		# clang 3.3 is the first release that completley implements the c++11 standard.
- 		# However, most of c++11 was implemented in previous versions.
- 		MESSAGE("clang ${CMAKE_CXX_COMPILER_VERSION} does not completely support c++11. This may cause some problems in the future. We recommend upgrading to clang-3.3 (Xcode 5.0) or greater.")
-	ENDIF (NOT (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER CLANG_MIN_VERSION OR CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL CLANG_MIN_VERSION))
-	# compiler is clang 3.3 or higher. Force c++11 and use libc++.
-	IF (XCODE_VERSION)
-		SET(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD c++11)
-		SET(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY libc++)
-	ELSE (XCODE_VERSION)
-		SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -stdlib=libc++")
-	ENDIF (XCODE_VERSION)
- 	UNSET(CLANG_MIN_VERSION)
+  execute_process(COMMAND ${CMAKE_CXX_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
+  IF (GCC_VERSION VERSION_GREATER 4.7 OR GCC_VERSION VERSION_EQUAL 4.7)
+    MESSAGE("Supported GCC!")
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+  ENDIF (GCC_VERSION VERSION_GREATER 4.7 OR GCC_VERSION VERSION_EQUAL 4.7)
+ELSEIF ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang") # Clang 3.3 and up support c++11.
+  MESSAGE("Clang Version: " ${CMAKE_CXX_COMPILER_VERSION})
+  # On OS X, Clang 3.3 would be Clang/LLVM 5.0.
+  IF (APPLE)
+    SET(CLANG_MIN_VERSION 5.0)
+  ELSE (APPLE)
+    SET(CLANG_MIN_VERSION 3.3)
+  ENDIF (APPLE)
+  IF (NOT (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER CLANG_MIN_VERSION OR CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL CLANG_MIN_VERSION))
+    # clang 3.3 is the first release that completley implements the c++11 standard.
+    # However, most of c++11 was implemented in previous versions.
+    MESSAGE("clang ${CMAKE_CXX_COMPILER_VERSION} does not completely support c++11. This may cause some problems in the future. We recommend upgrading to clang-3.3 (Xcode 5.0) or greater.")
+  ENDIF (NOT (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER CLANG_MIN_VERSION OR CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL CLANG_MIN_VERSION))
+  # compiler is clang 3.3 or higher. Force c++11 and use libc++.
+  IF (XCODE_VERSION)
+    SET(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD c++11)
+    SET(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY libc++)
+  ELSE (XCODE_VERSION)
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -stdlib=libc++")
+  ENDIF (XCODE_VERSION)
+  UNSET(CLANG_MIN_VERSION)
 ELSEIF (MSVC AND (MSVC_VERSION GREATER 1699))
-	MESSAGE("Supported Visual Studio!")
+  MESSAGE("Supported Visual Studio!")
 ELSE ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
-	MESSAGE(FATAL_ERROR "Your C++ compiler does not support C++11.")
+  MESSAGE(FATAL_ERROR "Your C++ compiler does not support C++11.")
 ENDIF ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
 
 IF(MINGW OR UNIX OR ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     # gtest requires pthread on *nix
-	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 ENDIF(MINGW OR UNIX OR ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
 SET(EXECUTABLE_OUTPUT_PATH ${CMAKE_SOURCE_DIR}/bin)
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/modules")
 
 IF (NOT (DEFINED TCC_BUILD_TESTS))
-	MESSAGE("Called independently.")
-	MESSAGE("The include directory ${CMAKE_SOURCE_DIR}/../include may not be correct.")
-	SET(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} ${CMAKE_SOURCE_DIR}/../include)
-	INCLUDE_DIRECTORIES("${CMAKE_SOURCE_DIR}/../include")
+  MESSAGE("Called independently.")
+  MESSAGE("The include directory ${CMAKE_SOURCE_DIR}/../include may not be correct.")
+  SET(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} ${CMAKE_SOURCE_DIR}/../include)
+  INCLUDE_DIRECTORIES("${CMAKE_SOURCE_DIR}/../include")
 ELSE (NOT (DEFINED TCC_BUILD_TESTS))
-	MESSAGE("Called from root.")
+  MESSAGE("Called from root.")
 ENDIF (NOT (DEFINED TCC_BUILD_TESTS))
 
 # If we are on windows add in the local search directories as well.
 IF (WIN32 AND NOT MINGW) # Windows
-	SET(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/lib/include/)
-	INCLUDE_DIRECTORIES("${CMAKE_CURRENT_SOURCE_DIR}/lib/include/")
-	IF (CMAKE_CL_64)
-		LINK_DIRECTORIES("${CMAKE_SOURCE_DIR}/lib")
-		SET(CMAKE_LIBRARY_PATH ${CMAKE_CURRENT_SOURCE_DIR}/lib)
-	ELSE (CMAKE_CL_64)
-		LINK_DIRECTORIES("${CMAKE_SOURCE_DIR}/lib")
-		SET(CMAKE_LIBRARY_PATH ${CMAKE_CURRENT_SOURCE_DIR}/lib)
-	ENDIF (CMAKE_CL_64)
+  SET(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/lib/include/)
+  INCLUDE_DIRECTORIES("${CMAKE_CURRENT_SOURCE_DIR}/lib/include/")
+  IF (CMAKE_CL_64)
+    LINK_DIRECTORIES("${CMAKE_SOURCE_DIR}/lib")
+    SET(CMAKE_LIBRARY_PATH ${CMAKE_CURRENT_SOURCE_DIR}/lib)
+  ELSE (CMAKE_CL_64)
+    LINK_DIRECTORIES("${CMAKE_SOURCE_DIR}/lib")
+    SET(CMAKE_LIBRARY_PATH ${CMAKE_CURRENT_SOURCE_DIR}/lib)
+  ENDIF (CMAKE_CL_64)
 ENDIF (WIN32 AND NOT MINGW)
 
-FIND_PACKAGE(GTEST REQUIRED)
+# Try to get GTest using a Env. variable, if not, with find_package
+IF (DEFINED ENV{GTEST_ROOT})
+  MESSAGE ("... using gtest found in $ENV{GTEST_ROOT}")
+  # Example : 
+  # GTEST_ROOT=path/gtest-1.6.0 ;
+  # export GTEST_ROOT 
+  ADD_SUBDIRECTORY ($ENV{GTEST_ROOT} ${CMAKE_CURRENT_BINARY_DIR}/gtest)
+  INCLUDE_DIRECTORIES ($ENV{GTEST_ROOT}/include $ENV{GTEST_ROOT})
+  SET (GTEST_LIBRARIES gtest)
+
+ELSE (DEFINED ENV{GTEST_ROOT})
+  FIND_PACKAGE(GTEST REQUIRED)
+
+ENDIF (DEFINED ENV{GTEST_ROOT})
 
 file(GLOB TCCTests_SRC "tests/*.h" "main.cpp")
 


### PR DESCRIPTION
I tweaked **CMakeLists** to allow to find **GTest** with the environment variable GTEST_ROOT. If it not find these variable, then will try to find it with find_package (find_package not always sworks well with GTest).

Also, have the initial version of **.travis.yml** with some commented lines that probably will need to uncomment  in a future when we begin to use third party libs.

I added a initial version of **.editorconfig** to "enforce" 4 spaces indent and unix file ending (your IDE/text editor should have the editor config plugin for this)
