### PR TITLE
Add TrillekAllocator

### DIFF
--- a/include/AtomicQueue.hpp
+++ b/include/AtomicQueue.hpp
@@ -5,11 +5,12 @@
 #include <atomic>
 #include <list>
 #include <memory>
+#include <TrillekAllocator.hpp>
 
 namespace trillek {
 
     template<class T>
-    using atomic_queue = std::list<T>;
+    using atomic_queue = std::list<T, TrillekAllocator<T>>;
 
     /** \brief A thread-safe queue implementation with atomic operations
      */

--- a/include/TrillekAllocator.hpp
+++ b/include/TrillekAllocator.hpp
@@ -1,0 +1,116 @@
+#ifndef TRILLEKALLOCATOR_HPP_INCLUDED
+#define TRILLEKALLOCATOR_HPP_INCLUDED
+
+extern size_t gAllocatedSize;
+
+namespace trillek {
+
+    template<typename T>
+    class TrillekAllocator {
+    public:
+        typedef size_t size_type;
+        typedef ptrdiff_t difference_type;
+        typedef T* pointer;
+        typedef const T* const_pointer;
+        typedef T& reference;
+        typedef const T& const_reference;
+        typedef T value_type;
+
+        /// Define a global that holds the allocated size
+
+        /// Default constructor
+        TrillekAllocator() throw()
+        {}
+        /// Copy constructor
+        TrillekAllocator(const TrillekAllocator&) throw()
+        {}
+        /// Copy constructor with another type
+        template<typename U>
+        TrillekAllocator(const TrillekAllocator<U>&) throw()
+        {}
+
+        /// Destructor
+        ~TrillekAllocator()
+        {}
+
+        /// Copy
+        TrillekAllocator<T>& operator=(const TrillekAllocator&)
+        {
+            return *this;
+        }
+        /// Copy with another type
+        template<typename U>
+        TrillekAllocator& operator=(const TrillekAllocator<U>&)
+        {
+            return *this;
+        }
+
+        /// Get address of reference
+        pointer address(reference x) const
+        {
+            return &x;
+        }
+        /// Get const address of const reference
+        const_pointer address(const_reference x) const
+        {
+            return &x;
+        }
+
+        /// Allocate memory
+        pointer allocate(size_type n, const void* = 0)
+        {
+            size_type size = n * sizeof(value_type);
+            gAllocatedSize += size;
+            return (pointer)::malloc(size);
+        }
+
+        /// Deallocate memory
+        void deallocate(void* p, size_type n)
+        {
+            size_type size = n * sizeof(T);
+            gAllocatedSize -= size;
+            ::free(p);
+        }
+
+        /// Call constructor
+        void construct(pointer p, const T& val)
+        {
+            // Placement new
+            new ((T*)p) T(val);
+        }
+        /// Call constructor with more arguments
+        template<typename U, typename... Args>
+        void construct(U* p, Args&&... args)
+        {
+            // Placement new
+            ::new((void*)p) U(std::forward<Args>(args)...);
+        }
+
+        /// Call the destructor of p
+        void destroy(pointer p)
+        {
+            p->~T();
+        }
+        /// Call the destructor of p of type U
+        template<typename U>
+        void destroy(U* p)
+        {
+            p->~U();
+        }
+
+        /// Get the max allocation size
+        size_type max_size() const
+        {
+            return size_type(-1);
+        }
+
+        /// A struct to rebind the allocator to another allocator of type U
+        template<typename U>
+        struct rebind
+        {
+            typedef TrillekAllocator<U> other;
+        };
+    };
+}
+
+#endif // TRILLEKALLOCATOR_HPP_INCLUDED

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,7 @@
+#include <cstddef>
+
+size_t gAllocatedSize = 0;
+
 int main(int argCount, char **argValues) {
 	return 0;
 }

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -3,6 +3,8 @@
 #include "tests/AtomicQueueTest.h"
 #include "tests/AtomicMapTest.h"
 
+size_t gAllocatedSize = 0;
+
 int main(int argc, char **argv) {
 	::testing::InitGoogleTest(&argc, argv);
 	int ret = RUN_ALL_TESTS();

--- a/tests/tests/AtomicQueueTest.h
+++ b/tests/tests/AtomicQueueTest.h
@@ -5,11 +5,13 @@
 
 #include "gtest/gtest.h"
 
+#define ELEMENT_SIZE    24 // storing an element allocates 24 bytes
+
 class AtomicQueueTest: public ::testing::Test {
 public:
     AtomicQueueTest() {};
 protected:
-    trillek::AtomicQueue<int> q;
+    trillek::AtomicQueue<uint32_t> q;
 };
 
 using trillek::AtomicQueue;
@@ -17,7 +19,7 @@ using trillek::AtomicQueue;
 namespace trillek {
     TEST_F(AtomicQueueTest, AtomicQueueEmpty) {
         ASSERT_TRUE(q.Empty()) << "New queue is not empty";
-        int i = 0;
+        uint32_t i = 0;
         ASSERT_FALSE(q.Pop(i)) << "New queue can pop inexisting element";
         ASSERT_EQ(i, 0) << "New queue popped  an element";
         ASSERT_TRUE(q.Poll().empty()) << "New polled queue gives elements";
@@ -25,54 +27,88 @@ namespace trillek {
 
     TEST_F(AtomicQueueTest, AtomicQueueOneElement) {
         q.Push(1);
+        ASSERT_EQ(gAllocatedSize, ELEMENT_SIZE) << "Wrong allocated size";
         ASSERT_FALSE(q.Empty()) << "Queue is empty";
-        int i = 0;
+        uint32_t i = 0;
         ASSERT_TRUE(q.Pop(i)) << "Queue can't pop existing element";
         ASSERT_EQ(i, 1) << "Queue popped  wrong value";
         ASSERT_TRUE(q.Empty()) << "Queue is not empty";
         ASSERT_TRUE(q.Poll().empty()) << "Polled queue gives elements";
+        ASSERT_EQ(gAllocatedSize, 0) << "Allocated size is not null";
     }
 
     TEST_F(AtomicQueueTest, AtomicQueuePoll) {
         q.Push(1);
         q.Push(2);
         ASSERT_FALSE(q.Empty()) << "Queue is empty";
+        ASSERT_EQ(gAllocatedSize, 2 * ELEMENT_SIZE) << "Wrong allocated size";
         auto ret = q.Poll();
         ASSERT_TRUE(q.Empty()) << "Queue is not empty";
         ASSERT_FALSE(ret.empty()) << "Returned list from Poll() is empty";
         ASSERT_EQ(ret.front(), 1) << "First element from Poll has wrong value";
+        ASSERT_EQ(gAllocatedSize, 2 * ELEMENT_SIZE) << "Wrong allocated size";
         ret.pop_front();
         ASSERT_FALSE(ret.empty()) << "Returned list from Poll() has only one element";
         ASSERT_EQ(ret.front(), 2) << "Second element from Poll has wrong value";
+        ASSERT_EQ(gAllocatedSize, ELEMENT_SIZE) << "Wrong allocated size";
         ret.pop_front();
         ASSERT_TRUE(ret.empty()) << "Returned list from Poll() has more than 2 elements";
+        ASSERT_EQ(gAllocatedSize, 0) << "Allocated size is not null";
     }
 
     TEST_F(AtomicQueueTest, AtomicQueuePop) {
         q.Push(1);
         q.Push(2);
         ASSERT_FALSE(q.Empty()) << "Queue is empty";
-        int i = 0;
+        ASSERT_EQ(gAllocatedSize, 2 * ELEMENT_SIZE) << "Wrong allocated size";
+        uint32_t i = 0;
         ASSERT_TRUE(q.Pop(i)) << "Queue can't pop existing element";
         ASSERT_EQ(i, 1) << "Pop()  wrong value";
         ASSERT_FALSE(q.Empty()) << "Queue is empty";
+        ASSERT_EQ(gAllocatedSize, ELEMENT_SIZE) << "Wrong allocated size";
         ASSERT_TRUE(q.Pop(i)) << "Queue can't pop existing element";
         ASSERT_EQ(i, 2) << "Pop()  wrong value";
         ASSERT_TRUE(q.Empty()) << "Queue is not empty";
         ASSERT_TRUE(q.Poll().empty()) << "Empty queue gives elements";
+        ASSERT_EQ(gAllocatedSize, 0) << "Allocated size is not null";
     }
 
-    TEST_F(AtomicQueueTest, AtomicQueueList) {
-        std::list<int> a{1,2,3,4,5};
+    TEST_F(AtomicQueueTest, AtomicQueueCopyList) {
+        std::list<uint32_t, TrillekAllocator<uint32_t>> a{1,2,3,4,5};
+        ASSERT_EQ(gAllocatedSize, 5 * ELEMENT_SIZE) << "Wrong allocated size";
         q.PushList(a);
-        ASSERT_FALSE(q.Empty()) << "Queue is empty";
+        ASSERT_FALSE(q.Empty()) << "Target queue is empty";
+        ASSERT_EQ(gAllocatedSize, 5 * ELEMENT_SIZE) << "Wrong allocated size";
         auto ret = q.Poll();
         ASSERT_TRUE(q.Empty()) << "Queue is not empty";
+        ASSERT_EQ(gAllocatedSize, 5 * ELEMENT_SIZE) << "Wrong allocated size";
         ASSERT_EQ(ret.size(), 5) << "Poll does not return all elements";
         for (auto i = 1; i < 6; ++i) {
             ASSERT_FALSE(ret.empty()) << "Returned list from Poll() is empty";
             ASSERT_EQ(ret.front(), i) << i << "th element from Poll has wrong value";
             ret.pop_front();
+            ASSERT_EQ(gAllocatedSize, (5 - i) * ELEMENT_SIZE) << "Wrong allocated size";
+        }
+        ASSERT_TRUE(q.Empty()) << "Queue is not empty";
+        ASSERT_TRUE(q.Poll().empty()) << "Polled queue gives elements";
+    }
+
+    TEST_F(AtomicQueueTest, AtomicQueueMoveList) {
+        auto alloc_backup = gAllocatedSize;
+        std::list<uint32_t, TrillekAllocator<uint32_t>> a{1,2,3,4,5};
+        ASSERT_EQ(gAllocatedSize, 5 * ELEMENT_SIZE) << "Wrong allocated size";
+        q.PushList(std::move(a));
+        ASSERT_FALSE(q.Empty()) << "Queue is empty";
+        ASSERT_EQ(gAllocatedSize, 5 * ELEMENT_SIZE) << "Wrong allocated size";
+        auto ret = q.Poll();
+        ASSERT_TRUE(q.Empty()) << "Queue is not empty";
+        ASSERT_EQ(gAllocatedSize, 5 * ELEMENT_SIZE) << "Wrong allocated size";
+        ASSERT_EQ(ret.size(), 5) << "Poll does not return all elements";
+        for (auto i = 1; i < 6; ++i) {
+            ASSERT_FALSE(ret.empty()) << "Returned list from Poll() is empty";
+            ASSERT_EQ(ret.front(), i) << i << "th element from Poll has wrong value";
+            ret.pop_front();
+            ASSERT_EQ(gAllocatedSize, (5 - i) * ELEMENT_SIZE) << "Wrong allocated size";
         }
         ASSERT_TRUE(q.Empty()) << "Queue is not empty";
         ASSERT_TRUE(q.Poll().empty()) << "Polled queue gives elements";


### PR DESCRIPTION
A simple memory allocator using the default allocator from http://anki3d.org/cpp-allocators-for-games/.

The global variable gAllocatedSize is available to know how many bytes are allocated.

AtomicQueue now uses it.

AtomicQueue tests were reinforced to check the usage of the allocator.
