### PR TITLE
Basic fix of previous commits

### DIFF
--- a/include/AtomicQueue.hpp
+++ b/include/AtomicQueue.hpp
@@ -9,13 +9,14 @@
 
 namespace trillek {
 
-    template<class T>
-    using atomic_queue = std::list<T, TrillekAllocator<T>>;
+/** \brief A thread-safe queue implementation with atomic operations
+ */
+template<class T>
+class AtomicQueue {
 
-    /** \brief A thread-safe queue implementation with atomic operations
-     */
-    template<class T>
-    class AtomicQueue {
+    template<class U>
+    using atomic_queue = std::list<U, TrillekAllocator<U>>;
+
     public:
 
         /** \brief Default constructor
@@ -99,7 +100,7 @@ namespace trillek {
         // the mutex protecting the queue
         mutable std::mutex mtx;
 
-    };
+};
 }
 
 

--- a/tests/tests/AtomicMapTest.h
+++ b/tests/tests/AtomicMapTest.h
@@ -16,37 +16,37 @@ protected:
 using trillek::AtomicMap;
 
 namespace trillek {
-    TEST_F(AtomicMapTest, AtomicMapEmpty) {
-        ASSERT_EQ(q.Count("a"), 0) << "New map is not empty";
-        int i = 0;
-        ASSERT_FALSE(q.Pop("a", i)) << "New map can pop inexisting element";
-        ASSERT_EQ(i, 0) << "New map popped  an element";
-        ASSERT_FALSE(q.Compare("a", 1)) << "Comparison in empty map should return false";
-        EXPECT_THROW(i = q.At("a"), std::out_of_range);
-    }
+TEST_F(AtomicMapTest, AtomicMapEmpty) {
+    ASSERT_EQ(q.Count("a"), 0) << "New map is not empty";
+    int i = 0;
+    ASSERT_FALSE(q.Pop("a", i)) << "New map can pop inexisting element";
+    ASSERT_EQ(i, 0) << "New map popped  an element";
+    ASSERT_FALSE(q.Compare("a", 1)) << "Comparison in empty map should return false";
+    EXPECT_THROW(i = q.At("a"), std::out_of_range);
+}
 
-    TEST_F(AtomicMapTest, AtomicMapOneElement) {
-        auto k = "a";
-        int i = 1;
-        q.Insert(k, i);
-        ASSERT_STREQ(k, "a") << "Insert moved lvalue key";
-        ASSERT_EQ(i, 1) << "Insert moved lvalue value";
-        ASSERT_EQ(q.Count(k), 1) << "Map is empty";
-        EXPECT_NO_THROW(i = q.At("a")) << "At throws an exception";
-        ASSERT_EQ(i, 1) << "At should return 1";
-        ASSERT_TRUE(q.Compare("a", 1)) << "Compare should return true";
-        ASSERT_FALSE(q.Compare("a", 2)) << "Compare should return false";
-        i = 0;
-        ASSERT_TRUE(q.Pop("a", i)) << "Map can't pop existing element";
-        ASSERT_EQ(i, 1) << "Map popped  wrong value";
-        ASSERT_EQ(q.Count(k), 0) << "Map is not empty";
-        EXPECT_THROW(i = q.At("a"), std::out_of_range) << "At does not throw when it should";
-    }
+TEST_F(AtomicMapTest, AtomicMapOneElement) {
+    auto k = "a";
+    int i = 1;
+    q.Insert(k, i);
+    ASSERT_STREQ(k, "a") << "Insert moved lvalue key";
+    ASSERT_EQ(i, 1) << "Insert moved lvalue value";
+    ASSERT_EQ(q.Count(k), 1) << "Map is empty";
+    EXPECT_NO_THROW(i = q.At("a")) << "At throws an exception";
+    ASSERT_EQ(i, 1) << "At should return 1";
+    ASSERT_TRUE(q.Compare("a", 1)) << "Compare should return true";
+    ASSERT_FALSE(q.Compare("a", 2)) << "Compare should return false";
+    i = 0;
+    ASSERT_TRUE(q.Pop("a", i)) << "Map can't pop existing element";
+    ASSERT_EQ(i, 1) << "Map popped  wrong value";
+    ASSERT_EQ(q.Count(k), 0) << "Map is not empty";
+    EXPECT_THROW(i = q.At("a"), std::out_of_range) << "At does not throw when it should";
+}
 
-    TEST_F(AtomicMapTest, AtomicMapErase) {
-        q.Insert("a", 1);
-        q.Erase("a");
-        ASSERT_EQ(q.Count("a"), 0) << "Map is not empty";
-    }
+TEST_F(AtomicMapTest, AtomicMapErase) {
+    q.Insert("a", 1);
+    q.Erase("a");
+    ASSERT_EQ(q.Count("a"), 0) << "Map is not empty";
+}
 }
 #endif // ATOMICMAPTEST_H_INCLUDED

--- a/tests/tests/AtomicQueueTest.h
+++ b/tests/tests/AtomicQueueTest.h
@@ -5,8 +5,6 @@
 
 #include "gtest/gtest.h"
 
-#define ELEMENT_SIZE    24 // storing an element allocates 24 bytes
-
 class AtomicQueueTest: public ::testing::Test {
 public:
     AtomicQueueTest() {};
@@ -17,101 +15,87 @@ protected:
 using trillek::AtomicQueue;
 
 namespace trillek {
-    TEST_F(AtomicQueueTest, AtomicQueueEmpty) {
-        ASSERT_TRUE(q.Empty()) << "New queue is not empty";
-        uint32_t i = 0;
-        ASSERT_FALSE(q.Pop(i)) << "New queue can pop inexisting element";
-        ASSERT_EQ(i, 0) << "New queue popped  an element";
-        ASSERT_TRUE(q.Poll().empty()) << "New polled queue gives elements";
-    }
+TEST_F(AtomicQueueTest, AtomicQueueEmpty) {
+    ASSERT_TRUE(q.Empty()) << "New queue is not empty";
+    uint32_t i = 0;
+    ASSERT_FALSE(q.Pop(i)) << "New queue can pop inexisting element";
+    ASSERT_EQ(i, 0) << "New queue popped  an element";
+    ASSERT_TRUE(q.Poll().empty()) << "New polled queue gives elements";
+}
 
-    TEST_F(AtomicQueueTest, AtomicQueueOneElement) {
-        q.Push(1);
-        ASSERT_EQ(gAllocatedSize, ELEMENT_SIZE) << "Wrong allocated size";
-        ASSERT_FALSE(q.Empty()) << "Queue is empty";
-        uint32_t i = 0;
-        ASSERT_TRUE(q.Pop(i)) << "Queue can't pop existing element";
-        ASSERT_EQ(i, 1) << "Queue popped  wrong value";
-        ASSERT_TRUE(q.Empty()) << "Queue is not empty";
-        ASSERT_TRUE(q.Poll().empty()) << "Polled queue gives elements";
-        ASSERT_EQ(gAllocatedSize, 0) << "Allocated size is not null";
-    }
+TEST_F(AtomicQueueTest, AtomicQueueOneElement) {
+    q.Push(1);
+    ASSERT_FALSE(q.Empty()) << "Queue is empty";
+    uint32_t i = 0;
+    ASSERT_TRUE(q.Pop(i)) << "Queue can't pop existing element";
+    ASSERT_EQ(i, 1) << "Queue popped  wrong value";
+    ASSERT_TRUE(q.Empty()) << "Queue is not empty";
+    ASSERT_TRUE(q.Poll().empty()) << "Polled queue gives elements";
+    ASSERT_EQ(gAllocatedSize, 0) << "Allocated size is not null";
+}
 
-    TEST_F(AtomicQueueTest, AtomicQueuePoll) {
-        q.Push(1);
-        q.Push(2);
-        ASSERT_FALSE(q.Empty()) << "Queue is empty";
-        ASSERT_EQ(gAllocatedSize, 2 * ELEMENT_SIZE) << "Wrong allocated size";
-        auto ret = q.Poll();
-        ASSERT_TRUE(q.Empty()) << "Queue is not empty";
+TEST_F(AtomicQueueTest, AtomicQueuePoll) {
+    q.Push(1);
+    q.Push(2);
+    ASSERT_FALSE(q.Empty()) << "Queue is empty";
+    auto ret = q.Poll();
+    ASSERT_TRUE(q.Empty()) << "Queue is not empty";
+    ASSERT_FALSE(ret.empty()) << "Returned list from Poll() is empty";
+    ASSERT_EQ(ret.front(), 1) << "First element from Poll has wrong value";
+    ret.pop_front();
+    ASSERT_FALSE(ret.empty()) << "Returned list from Poll() has only one element";
+    ASSERT_EQ(ret.front(), 2) << "Second element from Poll has wrong value";
+    ret.pop_front();
+    ASSERT_TRUE(ret.empty()) << "Returned list from Poll() has more than 2 elements";
+    ASSERT_EQ(gAllocatedSize, 0) << "Allocated size is not null";
+}
+
+TEST_F(AtomicQueueTest, AtomicQueuePop) {
+    q.Push(1);
+    q.Push(2);
+    ASSERT_FALSE(q.Empty()) << "Queue is empty";
+    uint32_t i = 0;
+    ASSERT_TRUE(q.Pop(i)) << "Queue can't pop existing element";
+    ASSERT_EQ(i, 1) << "Pop()  wrong value";
+    ASSERT_FALSE(q.Empty()) << "Queue is empty";
+    ASSERT_TRUE(q.Pop(i)) << "Queue can't pop existing element";
+    ASSERT_EQ(i, 2) << "Pop()  wrong value";
+    ASSERT_TRUE(q.Empty()) << "Queue is not empty";
+    ASSERT_TRUE(q.Poll().empty()) << "Empty queue gives elements";
+    ASSERT_EQ(gAllocatedSize, 0) << "Allocated size is not null";
+}
+
+TEST_F(AtomicQueueTest, AtomicQueueCopyList) {
+    std::list<uint32_t, TrillekAllocator<uint32_t>> a{1,2,3,4,5};
+    q.PushList(a);
+    ASSERT_FALSE(q.Empty()) << "Target queue is empty";
+    auto ret = q.Poll();
+    ASSERT_TRUE(q.Empty()) << "Queue is not empty";
+    ASSERT_EQ(ret.size(), 5) << "Poll does not return all elements";
+    for (auto i = 1; i < 6; ++i) {
         ASSERT_FALSE(ret.empty()) << "Returned list from Poll() is empty";
-        ASSERT_EQ(ret.front(), 1) << "First element from Poll has wrong value";
-        ASSERT_EQ(gAllocatedSize, 2 * ELEMENT_SIZE) << "Wrong allocated size";
+        ASSERT_EQ(ret.front(), i) << i << "th element from Poll has wrong value";
         ret.pop_front();
-        ASSERT_FALSE(ret.empty()) << "Returned list from Poll() has only one element";
-        ASSERT_EQ(ret.front(), 2) << "Second element from Poll has wrong value";
-        ASSERT_EQ(gAllocatedSize, ELEMENT_SIZE) << "Wrong allocated size";
+    }
+    ASSERT_TRUE(q.Empty()) << "Queue is not empty";
+    ASSERT_TRUE(q.Poll().empty()) << "Polled queue gives elements";
+}
+
+TEST_F(AtomicQueueTest, AtomicQueueMoveList) {
+    auto alloc_backup = gAllocatedSize;
+    std::list<uint32_t, TrillekAllocator<uint32_t>> a{1,2,3,4,5};
+    q.PushList(std::move(a));
+    ASSERT_FALSE(q.Empty()) << "Queue is empty";
+    auto ret = q.Poll();
+    ASSERT_TRUE(q.Empty()) << "Queue is not empty";
+    ASSERT_EQ(ret.size(), 5) << "Poll does not return all elements";
+    for (auto i = 1; i < 6; ++i) {
+        ASSERT_FALSE(ret.empty()) << "Returned list from Poll() is empty";
+        ASSERT_EQ(ret.front(), i) << i << "th element from Poll has wrong value";
         ret.pop_front();
-        ASSERT_TRUE(ret.empty()) << "Returned list from Poll() has more than 2 elements";
-        ASSERT_EQ(gAllocatedSize, 0) << "Allocated size is not null";
     }
-
-    TEST_F(AtomicQueueTest, AtomicQueuePop) {
-        q.Push(1);
-        q.Push(2);
-        ASSERT_FALSE(q.Empty()) << "Queue is empty";
-        ASSERT_EQ(gAllocatedSize, 2 * ELEMENT_SIZE) << "Wrong allocated size";
-        uint32_t i = 0;
-        ASSERT_TRUE(q.Pop(i)) << "Queue can't pop existing element";
-        ASSERT_EQ(i, 1) << "Pop()  wrong value";
-        ASSERT_FALSE(q.Empty()) << "Queue is empty";
-        ASSERT_EQ(gAllocatedSize, ELEMENT_SIZE) << "Wrong allocated size";
-        ASSERT_TRUE(q.Pop(i)) << "Queue can't pop existing element";
-        ASSERT_EQ(i, 2) << "Pop()  wrong value";
-        ASSERT_TRUE(q.Empty()) << "Queue is not empty";
-        ASSERT_TRUE(q.Poll().empty()) << "Empty queue gives elements";
-        ASSERT_EQ(gAllocatedSize, 0) << "Allocated size is not null";
-    }
-
-    TEST_F(AtomicQueueTest, AtomicQueueCopyList) {
-        std::list<uint32_t, TrillekAllocator<uint32_t>> a{1,2,3,4,5};
-        ASSERT_EQ(gAllocatedSize, 5 * ELEMENT_SIZE) << "Wrong allocated size";
-        q.PushList(a);
-        ASSERT_FALSE(q.Empty()) << "Target queue is empty";
-        ASSERT_EQ(gAllocatedSize, 5 * ELEMENT_SIZE) << "Wrong allocated size";
-        auto ret = q.Poll();
-        ASSERT_TRUE(q.Empty()) << "Queue is not empty";
-        ASSERT_EQ(gAllocatedSize, 5 * ELEMENT_SIZE) << "Wrong allocated size";
-        ASSERT_EQ(ret.size(), 5) << "Poll does not return all elements";
-        for (auto i = 1; i < 6; ++i) {
-            ASSERT_FALSE(ret.empty()) << "Returned list from Poll() is empty";
-            ASSERT_EQ(ret.front(), i) << i << "th element from Poll has wrong value";
-            ret.pop_front();
-            ASSERT_EQ(gAllocatedSize, (5 - i) * ELEMENT_SIZE) << "Wrong allocated size";
-        }
-        ASSERT_TRUE(q.Empty()) << "Queue is not empty";
-        ASSERT_TRUE(q.Poll().empty()) << "Polled queue gives elements";
-    }
-
-    TEST_F(AtomicQueueTest, AtomicQueueMoveList) {
-        auto alloc_backup = gAllocatedSize;
-        std::list<uint32_t, TrillekAllocator<uint32_t>> a{1,2,3,4,5};
-        ASSERT_EQ(gAllocatedSize, 5 * ELEMENT_SIZE) << "Wrong allocated size";
-        q.PushList(std::move(a));
-        ASSERT_FALSE(q.Empty()) << "Queue is empty";
-        ASSERT_EQ(gAllocatedSize, 5 * ELEMENT_SIZE) << "Wrong allocated size";
-        auto ret = q.Poll();
-        ASSERT_TRUE(q.Empty()) << "Queue is not empty";
-        ASSERT_EQ(gAllocatedSize, 5 * ELEMENT_SIZE) << "Wrong allocated size";
-        ASSERT_EQ(ret.size(), 5) << "Poll does not return all elements";
-        for (auto i = 1; i < 6; ++i) {
-            ASSERT_FALSE(ret.empty()) << "Returned list from Poll() is empty";
-            ASSERT_EQ(ret.front(), i) << i << "th element from Poll has wrong value";
-            ret.pop_front();
-            ASSERT_EQ(gAllocatedSize, (5 - i) * ELEMENT_SIZE) << "Wrong allocated size";
-        }
-        ASSERT_TRUE(q.Empty()) << "Queue is not empty";
-        ASSERT_TRUE(q.Poll().empty()) << "Polled queue gives elements";
-    }
+    ASSERT_TRUE(q.Empty()) << "Queue is not empty";
+    ASSERT_TRUE(q.Poll().empty()) << "Polled queue gives elements";
+}
 }
 #endif // ATOMICQUEUETEST_H_INCLUDED


### PR DESCRIPTION
Remove the tests that may fail when not using libstdc++, like MSVC.
Restrict the scope of an ambiguous typedef to the class where it is used to define a private member.
Fix style.
