### PR TITLE
Updated and improved scripts to semi-automate  prepare the build enviroment and build Trillek

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [ -f /usr/src/gtest/build/libgtest.a ]; then
+    echo "Instaled GTest"
+    GTEST_ROOT=/usr/src/gtest
+    export GTEST_ROOT
+    
+    #mkdir build
+    #cd build
+    cmake -DTCC_BUILD_TESTS=True -DTCC_TEST_NETWORK_DISABLE=True -DTRILLEK_BUILD_DEPENDENCY=True .
+else
+    cmake -DTCC_BUILD_TESTS=False -DTCC_TEST_NETWORK_DISABLE=True -DTRILLEK_BUILD_DEPENDENCY=True .
+fi
+
+echo "Compiling with English error/warings"
+LC_ALL=C make
+

--- a/prebuild.sh
+++ b/prebuild.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Bash script to install all dependencies
+
+echo "This script will try to download and install the necesary libs for Trillek engine on Ubuntu"
+BUILD_PATH=$(pwd)
+
+mkdir build
+
+# Get GLEW and GLM
+echo "Downloading GLEW and GLM"
+sudo apt-get -q -y install libglew-dev libglm-dev
+
+# Get Crypto++
+echo "Getting & compiling crypt++"
+git submodule update --init --depth 1 -- ./crypto++
+cd crypto++
+cmake CMakeLists.txt
+make
+cd $BUILD_PATH
+
+# OpenAL, Vorbis and OGG
+echo "OpenAL, Vorbis/OGG and Alure"
+sudo apt-get -q -y install libogg-dev libvorbis-dev libopenal-dev libalure-dev
+
+# Bullet
+BULLET_DOUBLE="$(pkg-config bullet --cflags | grep DOUBLE_PRECISION )"
+if [ -z "$BULLET_DOUBLE" ] ; then
+    # Bullet not installed with Double precision
+    echo "Installing and compiling bullet"
+    cd /tmp/
+    mkdir bullet
+    cd bullet
+    wget https://bullet.googlecode.com/files/bullet-2.82-r2704.tgz
+    tar -xzxf bullet-2.82-r2704.tgz
+    cmake -DINSTALL_LIBS=on -DBUILD_SHARED_LIBS=on -DBUILD_DEMOS=off -DUSE_DOUBLE_PRECISION=on  .
+    make
+    sudo make install
+else
+    echo "Bullet installed with double precision"
+fi
+cd $BUILD_PATH
+
+# install and build gtest
+if [ ! -f /usr/src/gtest/build/libgtest.a ]; then
+    echo "Instaling and compiling GTest"
+    sudo apt-get -q -y install libgtest-dev
+    cd /usr/src/gtest
+    sudo cmake CMakeLists.txt
+    sudo make
+    GTEST_ROOT=/usr/src/gtest
+    export GTEST_ROOT
+else
+    echo "GTest installed on /usr/src/gtest/"
+fi
+cd $BUILD_PATH
+
+# Get GLFW and compile it !
+GLFW_VERSION="$(pkg-config --modversion glfw3 | grep 3)"
+if [ -z "$GLFW_VERSION" ] ; then  # Should be >= 3
+    echo "Downloading and compiling GLFW"
+    cd /tmp/
+    sudo apt-get -qq install xorg-dev libglu1-mesa-dev
+    git clone https://github.com/glfw/glfw.git
+    cd glfw
+    CMAKE_CXX_FLAGS=-fPIC CMAKE_C_FLAGS=-fPIC cmake -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_SHARED_LIBS:bool=true .
+    sudo make install
+else
+    echo "GLFW $GLFW_VERSION is installed "
+fi
+cd $BUILD_PATH
+
+# Get RapidJSON
+if [ ! -f /usr/local/include/rapidjson/rapidjson.h ]; then
+    echo "Getting rapidjson"
+    wget https://rapidjson.googlecode.com/files/rapidjson-0.11.zip
+    unzip rapidjson-0.11.zip -d /tmp
+    sudo cp -r /tmp/rapidjson/include /usr/local
+else
+    echo "Rapidjson was installed previusly on /usr/local/include/rapidjson/"
+fi
+cd $BUILD_PATH
+
+echo "To build the engine, run build.sh"
+


### PR DESCRIPTION
 Added a basic bash scripts for Ubuntu 14.04 that should allow to setup and build Trillek. At least should help to see what is needed to build Trillek for anyone that try it for first time
- **prebuild.sh** Try to install and/or compile all necessary libs. In some case,s try to detect previously if some lib is pre-installed on the system (GLFW 3 , Bullet with double precision, GTest and RapidJSON).
- **build.sh** Executes cmake and try to compile Trillek 
